### PR TITLE
Allow creation of additional client certs

### DIFF
--- a/cmd/tlspark/main.go
+++ b/cmd/tlspark/main.go
@@ -1,17 +1,21 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"github.com/bnagy/enough"
+	"io/ioutil"
 	"log"
 	"os"
-
-	"github.com/bnagy/enough"
 )
 
 var (
-	name    = flag.String("name", "", "A short, shared service name eg 'WidgetCluser' (required)")
-	clients = flag.Int("clients", 1, "Number of client cert / keys to generate")
+	name         = flag.String("name", "", "A short, shared service name eg 'WidgetCluser' (required)")
+	clients      = flag.Int("clients", 1, "Number of client cert / keys to generate")
+	clientOffset = flag.Int("client-offset", 0, "Index to start minting new client certs from")
+	caCertPath   = flag.String("ca-cert", "", "Path to the CA cert pem file")
+	caKeyPath    = flag.String("ca-key", "", "Path to the CA private key pem file")
 )
 
 func output(c *enough.RawCert, stub string) {
@@ -53,28 +57,80 @@ func output(c *enough.RawCert, stub string) {
 	log.Printf("wrote %s, %s\n", certName, keyName)
 }
 
+/**
+ * Helper method which ensures all values are set and returns true if they are.
+ */
+func present(values ...string) bool {
+	for _, v := range values {
+		if len(v) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+/**
+ * Helper method to ensure the proper combination of flags was provided and attempt to create a CA
+ * either by requesting a new one from enough or using provided PEM data to instantiate one.
+ */
+func validateFlagsAndReturnCA() (ca *enough.CA, e error) {
+
+	var err error
+
+	if (!present(*name) && !present(*caCertPath) && !present(*caKeyPath)) || present(*name, *caCertPath, *caKeyPath) {
+		flag.Usage()
+		e = errors.New("name OR ca-cert and ca-key flag required!")
+	} else if present(*name) && len(*name) > 140 {
+		flag.Usage()
+		err = errors.New("Provided name is too long! Must be less than 140 characters.")
+	} else if present(*caCertPath, *caKeyPath) {
+		// Attempt to read cert and key files and create a CA struct from them
+		pemCert, err := ioutil.ReadFile(*caCertPath)
+		if err != nil {
+			e = fmt.Errorf("Failed to read ca-cert: %s", err)
+			return
+		}
+		pemKey, err := ioutil.ReadFile(*caKeyPath)
+		if err != nil {
+			e = fmt.Errorf("Failed to read ca-key: %s", err)
+			return
+		}
+		ca, e = enough.NewCAFromCertAndKey(pemCert, pemKey)
+
+	} else if present(*name) && !present(*caCertPath) && !present(*caKeyPath) {
+		// Create a new CA struct based on a service name
+		ca, err = enough.NewCA(*name)
+		if err != nil {
+			e = fmt.Errorf("Failed to create CA cert: %s", err)
+			return
+		}
+		output(&ca.Raw, "ca")
+
+		server, err := ca.CreateServerCert()
+		if err != nil {
+			e = fmt.Errorf("Failed to create cert: %s", err)
+			return
+		}
+		output(server, "server")
+
+	} else {
+		flag.Usage()
+		e = errors.New("name OR ca-cert and ca-key flag required!")
+	}
+	return
+}
+
 func main() {
-
+	var ca *enough.CA
 	flag.Parse()
-	if len(*name) == 0 {
-		flag.Usage()
-		log.Fatal("\nservice name required!")
-	}
-	if len(*name) > 140 {
-		flag.Usage()
-		log.Fatal("\nOh, grow up.")
-	}
 
-	ca, err := enough.NewCA(*name)
-	output(&ca.Raw, "ca")
-
-	server, err := ca.CreateServerCert()
+	ca, err := validateFlagsAndReturnCA()
 	if err != nil {
-		log.Fatalf("unable to create server cert: %s", err)
+		log.Fatalf("\nBad configuration flags: %s", err)
+		return
 	}
-	output(server, "server")
 
-	for i := 0; i < *clients; i++ {
+	for i := *clientOffset; i < (*clientOffset + *clients); i++ {
 		c, err := ca.CreateClientCert(i)
 		if err != nil {
 			log.Fatalf("unable to create cilent cert %d: %s", i, err)

--- a/cmd/tlspark/main.go
+++ b/cmd/tlspark/main.go
@@ -82,7 +82,7 @@ func validateFlagsAndReturnCA() (ca *enough.CA, e error) {
 		e = errors.New("name OR ca-cert and ca-key flag required!")
 	} else if present(*name) && len(*name) > 140 {
 		flag.Usage()
-		err = errors.New("Provided name is too long! Must be less than 140 characters.")
+		e = errors.New("Provided name is too long! Must be less than 140 characters.")
 	} else if present(*caCertPath, *caKeyPath) {
 		// Attempt to read cert and key files and create a CA struct from them
 		pemCert, err := ioutil.ReadFile(*caCertPath)

--- a/enough.go
+++ b/enough.go
@@ -37,6 +37,35 @@ type CA struct {
 	Service string
 }
 
+/**
+ * MakeCA
+ * Returns a new CA object based on pem data created by MarshalCertifcate and
+ * MarshalPrivateKey methods and read in from files.
+ */
+func NewCAFromCertAndKey(certPemData, keyPemData []byte) (ca *CA, e error) {
+	certPemBlock, _ := pem.Decode(certPemData)
+	keyPemBlock, _ := pem.Decode(keyPemData)
+
+	cert, e := x509.ParseCertificate(certPemBlock.Bytes)
+	if e != nil {
+		return
+	}
+
+	key, e := x509.ParseECPrivateKey(keyPemBlock.Bytes)
+	if e != nil {
+		return
+	}
+
+	// The certificate's subject common name is the service name with " CA" appended.
+	serviceName := cert.Subject.CommonName[0 : len(cert.Subject.CommonName)-3]
+	ca = &CA{
+		Raw:     RawCert{Certificate: *cert, PrivateKey: key},
+		Service: serviceName,
+	}
+
+	return
+}
+
 func NewCA(service string) (ca *CA, e error) {
 
 	name := pkix.Name{

--- a/enough_test.go
+++ b/enough_test.go
@@ -3,8 +3,32 @@ package enough
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"reflect"
 	"testing"
 )
+
+func TestNewCAFromCertAndKey(t *testing.T) {
+	t.Parallel()
+	ca, err := NewCA("testing")
+	if err != nil {
+		t.Fatalf("failed to create CA: %s", err)
+	}
+	pemCert, err := ca.Raw.MarshalCertificate()
+	if err != nil {
+		t.Fatalf("failed to marshal certificate: %s", err)
+	}
+	pemKey, err := ca.Raw.MarshalPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %s", err)
+	}
+	regenedCa, err := NewCAFromCertAndKey(pemCert, pemKey)
+	if err != nil {
+		t.Error("Cannot create CA from pem encoded cert and key")
+	}
+	if !reflect.DeepEqual(regenedCa, ca) {
+		t.Error("CA created is not equal to CA recreated with marshaled pem data")
+	}
+}
 
 func TestNewCA(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
A rough pass at allowing someone to return to tlspark with `ca_cert.pem` and `ca_key.pem` files and mint additional client certs.

The flag validation stuff is a little brutal but a simpler way didn't jump out at me.
